### PR TITLE
Fix/switch hymn

### DIFF
--- a/ChristInSong.xcodeproj/project.pbxproj
+++ b/ChristInSong.xcodeproj/project.pbxproj
@@ -72,8 +72,8 @@
 		087473772986BD0B00167974 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 087473752986BD0B00167974 /* GoogleService-Info.plist */; };
 		0874737929872FD600167974 /* HymnViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0874737829872FD600167974 /* HymnViewModel.swift */; };
 		0874737B298749D200167974 /* AlertState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0874737A298749D200167974 /* AlertState.swift */; };
-		08927D9324BEA5B60035972C /* HymnsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08927D9224BEA5B60035972C /* HymnsView.swift */; };
-		08927D9424BEA5B60035972C /* HymnsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08927D9224BEA5B60035972C /* HymnsView.swift */; };
+		08927D9324BEA5B60035972C /* HymnsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08927D9224BEA5B60035972C /* HymnsListView.swift */; };
+		08927D9424BEA5B60035972C /* HymnsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08927D9224BEA5B60035972C /* HymnsListView.swift */; };
 		08927D9724BEAAD00035972C /* CollectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08927D9624BEAAD00035972C /* CollectionsView.swift */; };
 		08927D9824BEAAD00035972C /* CollectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08927D9624BEAAD00035972C /* CollectionsView.swift */; };
 		08927D9B24BEAAFC0035972C /* SupportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08927D9A24BEAAFC0035972C /* SupportView.swift */; };
@@ -208,7 +208,7 @@
 		087473752986BD0B00167974 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		0874737829872FD600167974 /* HymnViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HymnViewModel.swift; sourceTree = "<group>"; };
 		0874737A298749D200167974 /* AlertState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertState.swift; sourceTree = "<group>"; };
-		08927D9224BEA5B60035972C /* HymnsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HymnsView.swift; sourceTree = "<group>"; };
+		08927D9224BEA5B60035972C /* HymnsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HymnsListView.swift; sourceTree = "<group>"; };
 		08927D9624BEAAD00035972C /* CollectionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionsView.swift; sourceTree = "<group>"; };
 		08927D9A24BEAAFC0035972C /* SupportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportView.swift; sourceTree = "<group>"; };
 		08927D9E24BEAB1F0035972C /* InfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoView.swift; sourceTree = "<group>"; };
@@ -409,7 +409,7 @@
 			isa = PBXGroup;
 			children = (
 				08927DA124BEAC110035972C /* Hymnals */,
-				08927D9224BEA5B60035972C /* HymnsView.swift */,
+				08927D9224BEA5B60035972C /* HymnsListView.swift */,
 				08927E3F24C3F8230035972C /* HymnView.swift */,
 				0874737829872FD600167974 /* HymnViewModel.swift */,
 			);
@@ -848,7 +848,7 @@
 				08624FA124DBA67E00AF2904 /* StringExtensions.swift in Sources */,
 				08CB346625E4C5DE00609D65 /* Constants.swift in Sources */,
 				67A174BF285F1459006A5BC1 /* View+Extensions.swift in Sources */,
-				08927D9324BEA5B60035972C /* HymnsView.swift in Sources */,
+				08927D9324BEA5B60035972C /* HymnsListView.swift in Sources */,
 				081801D825EA43D10053D295 /* CheckBoxView.swift in Sources */,
 				08C3C0A225F08E81004194B2 /* FontExtensions.swift in Sources */,
 				67A174BC285F1402006A5BC1 /* UIApplication+Extensions.swift in Sources */,
@@ -904,7 +904,7 @@
 				08927D9C24BEAAFC0035972C /* SupportView.swift in Sources */,
 				08C3C0A325F08E81004194B2 /* FontExtensions.swift in Sources */,
 				08624FA224DBA67E00AF2904 /* StringExtensions.swift in Sources */,
-				08927D9424BEA5B60035972C /* HymnsView.swift in Sources */,
+				08927D9424BEA5B60035972C /* HymnsListView.swift in Sources */,
 				08C0929E25F74FE500845BA1 /* NavItem.swift in Sources */,
 				08927E4624C402BF0035972C /* HymnalView.swift in Sources */,
 				086C942724BE93BD008AFBE5 /* ContentView.swift in Sources */,

--- a/Shared/Common/Constants.swift
+++ b/Shared/Common/Constants.swift
@@ -19,10 +19,7 @@ struct Constants {
         let versionString = Bundle.versionString
         let versionCode = Bundle.versionCode
         
-        if !versionString.isEmpty && !versionCode.isEmpty {
-            return "v\(versionString) (\(versionCode))"
-        } else {
-            return ""
-        }
+        return (!versionString.isEmpty && !versionCode.isEmpty) ?
+        "v\(versionString) (\(versionCode))" : ""
     }
 }

--- a/Shared/ContentView.swift
+++ b/Shared/ContentView.swift
@@ -18,7 +18,7 @@ struct ContentView: View {
         
         if (idiom == .phone) {
             TabView(selection: $selection) {
-                HymnsView()
+                HymnsListView()
                     .tabItem {
                         NavLabel(item: NavItem.hymns)
                     }
@@ -49,7 +49,7 @@ struct ContentView: View {
                         .frame(minWidth: 200, idealWidth: 250, maxWidth: 300)
                 #endif
                
-                HymnsView()
+                HymnsListView()
             }
         }
         
@@ -57,7 +57,7 @@ struct ContentView: View {
     
     private var sidebarContent: some View {
         List {
-            NavigationLink(destination: HymnsView()) {
+            NavigationLink(destination: HymnsListView()) {
                 NavLabel(item: NavItem.hymns)
             }
             
@@ -77,8 +77,9 @@ struct ContentView: View {
     }
 }
 
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
-    }
-}
+//struct ContentView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        ContentView()
+//    }
+//}
+

--- a/Shared/ContentView.swift
+++ b/Shared/ContentView.swift
@@ -77,9 +77,9 @@ struct ContentView: View {
     }
 }
 
-//struct ContentView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        ContentView()
-//    }
-//}
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}
 

--- a/Shared/Features/Hymns/HymnView.swift
+++ b/Shared/Features/Hymns/HymnView.swift
@@ -28,7 +28,7 @@ struct HymnView: View {
                 EmptyView()
             }
         }
-        .navigationTitle(viewModel.model?.bookTitle ?? "")
+        .navigationTitle(hymn.bookTitle)
         .toolbar {
             ToolbarItemGroup {
                 Button(action: { showCollectionModal.toggle() }) {
@@ -43,12 +43,12 @@ struct HymnView: View {
             }
         }
         .sheet(isPresented: $showCollectionModal) {
-            if let model = viewModel.model {
-                AddToCollectionView(hymnId: model.id, onDismiss: {
+                AddToCollectionView(hymnId: hymn.id, onDismiss: {
                     showCollectionModal.toggle()
+                    viewModel.model = hymn
                 })
                 .environment(\.managedObjectContext, PersistenceController.shared.container.viewContext)
-            }
+
         }
         .sheet(isPresented: $showHymnalsModal) {
             HymnalsView(hymnal: viewModel.hymnal?.id ?? hymnal) { item in

--- a/Shared/Features/Hymns/HymnView.swift
+++ b/Shared/Features/Hymns/HymnView.swift
@@ -28,7 +28,7 @@ struct HymnView: View {
                 EmptyView()
             }
         }
-        .navigationTitle(hymn.bookTitle)
+        .navigationTitle(viewModel.model?.bookTitle ?? hymn.bookTitle)
         .toolbar {
             ToolbarItemGroup {
                 Button(action: { showCollectionModal.toggle() }) {

--- a/Shared/Features/Hymns/HymnViewModel.swift
+++ b/Shared/Features/Hymns/HymnViewModel.swift
@@ -13,7 +13,7 @@ class HymnViewModel : ObservableObject {
         PersistenceController.shared
     }()
     
-    @Published private(set) var model: HymnModel?
+    @Published var model: HymnModel?
     @Published private(set) var hymnal: HymnalModel?
     @Published private(set) var currState: (message: String, state: AlertState)?
     @Published var showingHUD = false

--- a/Shared/Features/Hymns/HymnsListView.swift
+++ b/Shared/Features/Hymns/HymnsListView.swift
@@ -12,7 +12,7 @@ private enum Sort: String {
     case title = "titleStr"
 }
 
-struct HymnsView: View {
+struct HymnsListView: View {
     
     private var idiom : UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
     
@@ -103,7 +103,7 @@ struct HymnsView: View {
 struct HymnsView_Previews: PreviewProvider {
     static var previews: some View {
         ForEach(["iPhone SE", "iPhone XS Max", "iPad Pro (11-inch) (2nd generation)"], id: \.self) { deviceName in
-            HymnsView()
+            HymnsListView()
                 .previewDevice(PreviewDevice(rawValue: deviceName))
         }
         


### PR DESCRIPTION
# What did you change:

Solves Issue #23 
- Rename `HymnsView()` to `HymnsListView()` to reduce ambiguity
- Use the instance on hymn set during view appear, and propagate the to the viewmodel, to ensure that we are maintaining one source of truth. 

# Screenshot/GIFs of this change
![switch_hymn_title_bug_fix](https://user-images.githubusercontent.com/64806625/216927825-79179bbf-3b54-4cf4-8a76-cabd05bd1599.gif)