### PR TITLE
Support hymns in markdown format

### DIFF
--- a/ChristInSong.xcodeproj/project.pbxproj
+++ b/ChristInSong.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -65,6 +65,7 @@
 		087473762986BD0B00167974 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 087473752986BD0B00167974 /* GoogleService-Info.plist */; };
 		087473772986BD0B00167974 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 087473752986BD0B00167974 /* GoogleService-Info.plist */; };
 		0874737B298749D200167974 /* AlertState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0874737A298749D200167974 /* AlertState.swift */; };
+		0876892C2B4B2D9500D630BA /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 0876892B2B4B2D9500D630BA /* MarkdownUI */; };
 		08927D9324BEA5B60035972C /* HymnsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08927D9224BEA5B60035972C /* HymnsView.swift */; };
 		08927D9424BEA5B60035972C /* HymnsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08927D9224BEA5B60035972C /* HymnsView.swift */; };
 		08927D9724BEAAD00035972C /* CollectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08927D9624BEAAD00035972C /* CollectionsView.swift */; };
@@ -236,6 +237,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0876892C2B4B2D9500D630BA /* MarkdownUI in Frameworks */,
 				7171DECB21D09E811EF29010 /* Pods_iOS.framework in Frameworks */,
 				084BDAA725FD9CF8002090CD /* StoreKit.framework in Frameworks */,
 			);
@@ -602,6 +604,9 @@
 			dependencies = (
 			);
 			name = iOS;
+			packageProductDependencies = (
+				0876892B2B4B2D9500D630BA /* MarkdownUI */,
+			);
 			productName = iOS;
 			productReference = 086C940224BE93BD008AFBE5 /* ChristInSong.app */;
 			productType = "com.apple.product-type.application";
@@ -672,6 +677,9 @@
 				Base,
 			);
 			mainGroup = 086C93F524BE93BC008AFBE5;
+			packageReferences = (
+				0876892A2B4B2D9500D630BA /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
+			);
 			productRefGroup = 086C940324BE93BD008AFBE5 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1217,6 +1225,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		0876892A2B4B2D9500D630BA /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.3.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		0876892B2B4B2D9500D630BA /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0876892A2B4B2D9500D630BA /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
+			productName = MarkdownUI;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
 		08CB33EB25E22DD200609D65 /* Main.xcdatamodeld */ = {

--- a/ChristInSong.xcodeproj/project.pbxproj
+++ b/ChristInSong.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		084BDAA925FD9DAA002090CD /* StoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084BDAA825FD9DAA002090CD /* StoreManager.swift */; };
 		08624FA124DBA67E00AF2904 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08624FA024DBA67E00AF2904 /* StringExtensions.swift */; };
 		08624FA224DBA67E00AF2904 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08624FA024DBA67E00AF2904 /* StringExtensions.swift */; };
+		086ACA5A29DA6C3B00F9AF45 /* kinyarwanda.json in Resources */ = {isa = PBXBuildFile; fileRef = 086ACA5929DA6C3B00F9AF45 /* kinyarwanda.json */; };
+		086ACA5B29DA6C3B00F9AF45 /* kinyarwanda.json in Resources */ = {isa = PBXBuildFile; fileRef = 086ACA5929DA6C3B00F9AF45 /* kinyarwanda.json */; };
 		086C942424BE93BD008AFBE5 /* ChristInSongApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086C93FB24BE93BC008AFBE5 /* ChristInSongApp.swift */; };
 		086C942524BE93BD008AFBE5 /* ChristInSongApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086C93FB24BE93BC008AFBE5 /* ChristInSongApp.swift */; };
 		086C942624BE93BD008AFBE5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086C93FC24BE93BC008AFBE5 /* ContentView.swift */; };
@@ -151,6 +153,7 @@
 		084BDAA625FD9CF8002090CD /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.4.sdk/System/Library/Frameworks/StoreKit.framework; sourceTree = DEVELOPER_DIR; };
 		084BDAA825FD9DAA002090CD /* StoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreManager.swift; sourceTree = "<group>"; };
 		08624FA024DBA67E00AF2904 /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
+		086ACA5929DA6C3B00F9AF45 /* kinyarwanda.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = kinyarwanda.json; sourceTree = "<group>"; };
 		086C93FB24BE93BC008AFBE5 /* ChristInSongApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChristInSongApp.swift; sourceTree = "<group>"; };
 		086C93FC24BE93BC008AFBE5 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		086C93FD24BE93BD008AFBE5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -327,6 +330,7 @@
 		087473412986BC0100167974 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				086ACA5929DA6C3B00F9AF45 /* kinyarwanda.json */,
 				1D1A914A29BFCA60003C3260 /* config.json */,
 				087473472986BC3F00167974 /* abagusii.json */,
 				0874734A2986BC3F00167974 /* chichewa.json */,
@@ -694,6 +698,7 @@
 				0874735B2986BC3F00167974 /* abagusii.json in Resources */,
 				087473672986BC3F00167974 /* gikuyu.json in Resources */,
 				087473762986BD0B00167974 /* GoogleService-Info.plist in Resources */,
+				086ACA5A29DA6C3B00F9AF45 /* kinyarwanda.json in Resources */,
 				087473572986BC3F00167974 /* xitsonga.json in Resources */,
 				087473612986BC3F00167974 /* chichewa.json in Resources */,
 				087473652986BC3F00167974 /* ndebele.json in Resources */,
@@ -720,6 +725,7 @@
 				0874735C2986BC3F00167974 /* abagusii.json in Resources */,
 				087473682986BC3F00167974 /* gikuyu.json in Resources */,
 				087473772986BD0B00167974 /* GoogleService-Info.plist in Resources */,
+				086ACA5B29DA6C3B00F9AF45 /* kinyarwanda.json in Resources */,
 				087473582986BC3F00167974 /* xitsonga.json in Resources */,
 				087473622986BC3F00167974 /* chichewa.json in Resources */,
 				087473662986BC3F00167974 /* ndebele.json in Resources */,

--- a/ChristInSongTests/StoreSpy.swift
+++ b/ChristInSongTests/StoreSpy.swift
@@ -134,7 +134,7 @@ extension StoreBook {
 extension StoreHymn {
     
     static func hymn(_ id: UUID = UUID(), number: Int = 1, book: String = .defaultBookKey) -> StoreHymn {
-        StoreHymn(id: id, title: "Dummy Title", titleStr: "Dummy Title", content: "a very long hymn", book: book, number: number)
+        StoreHymn(id: id, title: "Dummy Title", titleStr: "Dummy Title", html: "a very long hymn", markdown: nil, book: book, number: number)
     }
 }
 

--- a/Hymn+CoreDataProperties.swift
+++ b/Hymn+CoreDataProperties.swift
@@ -18,6 +18,7 @@ extension Hymn {
 
     @NSManaged public var book: String?
     @NSManaged public var content: String?
+    @NSManaged public var markdown: String?
     @NSManaged public var edited_content: String?
     @NSManaged public var id: UUID?
     @NSManaged public var number: Int16
@@ -52,7 +53,7 @@ extension Hymn : Identifiable {
         titleStr ?? wrappedTitle.titleStr
     }
     var wrappedContent: String {
-        content ?? ""
+        content ?? (markdown ?? "")
     }
     var collections: [Collection] {
         let set = collection as? Set<Collection> ?? []

--- a/Shared/CISStore/CISCoreDataStore.swift
+++ b/Shared/CISStore/CISCoreDataStore.swift
@@ -270,11 +270,15 @@ extension CISCoreDataStore {
             hymn.title = hymnFromFile.title
             hymn.titleStr = hymnFromFile.title.titleStr
             hymn.number = Int16(hymnFromFile.number)
-            if hymnFromFile.content.contains(hymnFromFile.title) {
-                hymn.content = hymnFromFile.content
-            } else {
-                hymn.content = "<h3>\(hymnFromFile.title)</h3>\(hymnFromFile.content)"
+        
+            if let html = hymnFromFile.content {
+                if html.contains(hymnFromFile.title) {
+                    hymn.content = html
+                } else {
+                    hymn.content = "<h3>\(hymnFromFile.title)</h3>\(html)"
+                }
             }
+            hymn.markdown = hymnFromFile.markdown
             
             hymn.edited_content = hymn.content
             
@@ -306,7 +310,8 @@ extension CISCoreDataStore {
     private struct LocalHymn: Decodable {
         let title: String
         let number: Int
-        let content: String
+        let content: String?
+        let markdown: String?
     }
 }
 

--- a/Shared/Common/Data/Main.xcdatamodeld/Main.xcdatamodel/contents
+++ b/Shared/Common/Data/Main.xcdatamodeld/Main.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="20D74" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22E252" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Collection" representedClassName="Collection" syncable="YES">
         <attribute name="about" optional="YES" attributeType="String"/>
         <attribute name="created" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -12,13 +12,10 @@
         <attribute name="content" optional="YES" attributeType="String"/>
         <attribute name="edited_content" optional="YES" attributeType="String"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="markdown" optional="YES" attributeType="String"/>
         <attribute name="number" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" optional="YES" attributeType="String"/>
         <attribute name="titleStr" optional="YES" attributeType="String"/>
         <relationship name="collection" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Collection" inverseName="hymns" inverseEntity="Collection"/>
     </entity>
-    <elements>
-        <element name="Collection" positionX="-63" positionY="27" width="128" height="104"/>
-        <element name="Hymn" positionX="-63" positionY="-18" width="128" height="149"/>
-    </elements>
 </model>

--- a/Shared/Features/Collections/View/CollectionItemView.swift
+++ b/Shared/Features/Collections/View/CollectionItemView.swift
@@ -38,7 +38,7 @@ struct CollectionItemView: View {
 struct CollectionItemView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            CollectionRowView(item: .init(id: UUID(), title: "Favorite Hymns", dateCreated: .now, hymns: [.init(id: UUID(), title: "Test Hymn", titleStr: "Test Hymn", content: "An amazing hymn", book: .defaultBook, number: 1)]), selected: false)
+            CollectionRowView(item: .init(id: UUID(), title: "Favorite Hymns", dateCreated: .now, hymns: [.init(id: UUID(), title: "Test Hymn", titleStr: "Test Hymn", html: "An amazing hymn", markdown: nil, book: .defaultBook, number: 1)]), selected: false)
         }
     }
 }

--- a/Shared/Features/Hymns/HymnView.swift
+++ b/Shared/Features/Hymns/HymnView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import WebKit
+import MarkdownUI
 
 struct HymnView: View {
     @EnvironmentObject var vm: CISAppViewModel
@@ -64,8 +65,7 @@ struct HymnView: View {
                 HTMLText(html: html)
             } else if let markdown = displayedHymn.markdown {
                 ScrollView {
-                   Text(LocalizedStringKey(markdown))
-                        .bodyStyle()
+                    Markdown(markdown)
                         .textSelection(.enabled)
                         .padding()
                 }

--- a/Shared/Features/Hymns/HymnView.swift
+++ b/Shared/Features/Hymns/HymnView.swift
@@ -43,9 +43,18 @@ struct HymnView: View {
     var body: some View {
         
         ZStack {
-            HTMLText(html: displayedHymn.content)
+            if let html = displayedHymn.html {
+                HTMLText(html: html)
+            } else if let markdown = displayedHymn.markdown {
+                ScrollView {
+                   Text(LocalizedStringKey(markdown))
+                        .bodyStyle()
+                        .textSelection(.enabled)
+                        .padding()
+                }
+            }
         }
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleDisplayMode(.automatic)
         .navigationBarBackButtonHidden()
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
@@ -107,7 +116,7 @@ struct HymnView: View {
 struct OldHymnView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            HymnView( displayedHymn: .init(id: UUID(), title: "1. Watchman Blow The Gospel Trumpet", titleStr: "Watchman Blow The Gospel Trumpet", content: "<h1>1 Watchman Blow The Gospel Trumpet.</h1>\n<p>\nWatchman, blow the gospel trumpet,<br/>\nEvery  soul a warning give;<br/>\n Whosoever hears the message <br/>\nMay repent, and turn, and live.", book: .defaultBook, number: 1))
+            HymnView( displayedHymn: .init(id: UUID(), title: "1. Watchman Blow The Gospel Trumpet", titleStr: "Watchman Blow The Gospel Trumpet", html: "<h1>1 Watchman Blow The Gospel Trumpet.</h1>\n<p>\nWatchman, blow the gospel trumpet,<br/>\nEvery  soul a warning give;<br/>\n Whosoever hears the message <br/>\nMay repent, and turn, and live.", markdown: nil, book: .defaultBook, number: 1))
         }
         .previewDevice(PreviewDevice(rawValue: "iPhone 14 Pro"))
     }

--- a/Shared/Features/Hymns/HymnsView.swift
+++ b/Shared/Features/Hymns/HymnsView.swift
@@ -21,7 +21,8 @@ struct HymnsView: View {
         } else {
             return vm.hymnsFromSelectedBook.filter {
                 $0.title.localizedCaseInsensitiveContains(filterQuery) ||
-                $0.content.localizedCaseInsensitiveContains(filterQuery)
+                ($0.html ?? "").localizedCaseInsensitiveContains(filterQuery) ||
+                ($0.markdown ?? "").localizedCaseInsensitiveContains(filterQuery)
             }
         }
     }

--- a/Shared/Store/Store.swift
+++ b/Shared/Store/Store.swift
@@ -47,7 +47,7 @@ public protocol Store {
 
 extension Hymn {
     func toStoreHymn() -> StoreHymn {
-        StoreHymn(id: self.id!, title: self.title!, titleStr: self.titleStr!, content: self.content!, book: self.book!, number: Int(self.number))
+        StoreHymn(id: self.id!, title: self.title!, titleStr: self.titleStr!, html: self.content, markdown: self.markdown ?? nil, book: self.book!, number: Int(self.number))
     }
 }
 

--- a/Shared/Store/StoreHymn.swift
+++ b/Shared/Store/StoreHymn.swift
@@ -14,8 +14,10 @@ public struct StoreHymn: Identifiable, Equatable {
     public let title: String
     /// Title of the Hymn with the number inverted
     public let titleStr: String
-    /// Content of the Hymn
-    public let content: String
+    /// Content of the Hymn in html
+    public let html: String?
+    /// Content of the Hymn in markdown
+    public let markdown: String?
     /// Modified version of thy hymn, defaults to content
     public let editedContent: String?
     /// Key to book to which the hymn belongs
@@ -23,11 +25,12 @@ public struct StoreHymn: Identifiable, Equatable {
     /// Hymn number
     public let number: Int
     
-    public init(id: UUID, title: String, titleStr: String, content: String, editedContent: String? = nil, book: String, number: Int) {
+    public init(id: UUID, title: String, titleStr: String, html: String?, markdown: String?, editedContent: String? = nil, book: String, number: Int) {
         self.id = id
         self.title = title
         self.titleStr = titleStr
-        self.content = content
+        self.html = html
+        self.markdown = markdown
         self.editedContent = editedContent
         self.book = book
         self.number = number


### PR DESCRIPTION
# What did you change:

Adding initial support for hymns in markdown format.


Unfortunately SwiftUi doesn't support headers yet 😞 so the formatting is off.

# Screenshot/GIFs of this change

![snap](https://user-images.githubusercontent.com/5994683/229405562-ecaee289-dbcb-4b9e-9220-df359bcc99a7.png)



# Merge checklist

- [ ] Automated (unit/ui) tests
- [x] Manual tests